### PR TITLE
Update f3-(linux).txt

### DIFF
--- a/_pages/en_US/f3-(linux).txt
+++ b/_pages/en_US/f3-(linux).txt
@@ -14,7 +14,7 @@ This page is for Linux users only. If you are not on Linux, check out the [H2tes
 
 ### What You Need
 
-* The latest version of [F3](https://github.com/AltraMayor/f3/archive/v6.0.zip)
+* The latest version of [F3](https://github.com/AltraMayor/f3/archive/v7.0.zip)
 
 ### Instructions
 


### PR DESCRIPTION
Update download link for F3
I think it would be even better to use the [Releases URL](https://github.com/AltraMayor/f3/releases) instead of a direct download link, in case of a new F3 version