### PR TITLE
Update URL for 3DS guide

### DIFF
--- a/_pages/en_US/home.txt
+++ b/_pages/en_US/home.txt
@@ -19,7 +19,7 @@ Thoroughly read all of the introductory pages (including this one!) before proce
 
 {% capture notice-home %}
 This guide is for developer ("PANDA") consoles *only*!    
-If you have a retail (consumer purchased; not from the Nintendo Developer Program) console, check out the [retail 3DS Hacks Guide](https://3ds.guide)
+If you have a retail (consumer purchased; not from the Nintendo Developer Program) console, check out the [retail 3DS Hacks Guide](https://3ds.hacks.guide)
 {% endcapture %}
 
 <div class="notice--danger">{{ notice-home | markdownify }}</div>


### PR DESCRIPTION
The current URL (3ds.guide) correctly redirects to the actual one (3ds.hacks.guide), but changing spares a redirection and increases maintainability in case the old domain goes down for whatever reason.